### PR TITLE
Add ResponseCode.isError(), SDK updates

### DIFF
--- a/AndroidBillingLibrary/.settings/org.eclipse.jdt.core.prefs
+++ b/AndroidBillingLibrary/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.source=1.5

--- a/AndroidBillingLibrary/project.properties
+++ b/AndroidBillingLibrary/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-13
+target=android-16

--- a/AndroidBillingLibrary/project.properties
+++ b/AndroidBillingLibrary/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-16
+target=android-17

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingRequest.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingRequest.java
@@ -188,9 +188,23 @@ public abstract class BillingRequest {
     	RESULT_DEVELOPER_ERROR, // 5
     	RESULT_ERROR; // 6
 
-    	public static boolean isResponseOk(int response) {
-    		return ResponseCode.RESULT_OK.ordinal() == response;
-    	}
+		public boolean isOkay() {
+			return this.equals(RESULT_OK);
+		}
+
+		public boolean isError() {
+			return !this.isOkay() && !this.equals(RESULT_USER_CANCELED);
+		}
+
+		public static boolean isResponseOk(int response) {
+			return ResponseCode.RESULT_OK.ordinal() == response;
+		}
+
+		public static boolean isResponseError(int response) {
+			final boolean isOkay = ResponseCode.RESULT_OK.ordinal() == response;
+			final boolean isCancel = ResponseCode.RESULT_USER_CANCELED.ordinal() == response;
+			return !isOkay && !isCancel;
+		}
 
     	// Converts from an ordinal value to the ResponseCode
     	public static ResponseCode valueOf(int index) {

--- a/AndroidBillingLibraryTest/.settings/org.eclipse.jdt.core.prefs
+++ b/AndroidBillingLibraryTest/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.source=1.5

--- a/AndroidBillingLibraryTest/project.properties
+++ b/AndroidBillingLibraryTest/project.properties
@@ -12,4 +12,4 @@
 
 android.library.reference.1=../AndroidBillingLibrary
 # Project target.
-target=android-13
+target=android-17

--- a/DungeonsRedux/.settings/org.eclipse.jdt.core.prefs
+++ b/DungeonsRedux/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.source=1.5

--- a/DungeonsRedux/project.properties
+++ b/DungeonsRedux/project.properties
@@ -12,4 +12,4 @@
 
 android.library.reference.1=../AndroidBillingLibrary
 # Project target.
-target=android-4
+target=android-17


### PR DESCRIPTION
This is a small utility function I added. It seemed like something I naturally wanted to check since it only makes sense for me to log error cases.

---

Default to latest SDK (API Level 17)

Fixes robotmedia/#103

---

Add ResponseCode.isError(), isResponseError(int)

Anything other than OK and USER_CANCELED is considered an error.

ResponseCode.isOkay() was also added.
